### PR TITLE
Change master branch to main branch in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ disabled for non-administrative users via group policies.
    * Using **Git**:
       1. Clone the project into a local directory, e.g.
          ```batch
-         git clone https://github.com/vegardit/cygwin-portable-installer --single-branch --branch master --depth 1 C:\apps\cygwin-portable
+         git clone https://github.com/vegardit/cygwin-portable-installer --single-branch --branch main --depth 1 C:\apps\cygwin-portable
          ```
 1. (Optional) Open the file [cygwin-portable-installer.cmd](cygwin-portable-installer.cmd) in a text editor and adjust the configuration variables to e.g. set an HTTP Proxy, change the set of pre-installed Cygwin packages, select the terminal (ConEmu or Mintty), etc.
 1. (Optional) Temporarily disable your Antivirus scanner in case it is known to interfere with Cygwin, otherwise you may end-up with a broken/incomplete installation. See [cygwin.com/faq: What applications have been found to interfere with Cygwin?](https://cygwin.com/faq/faq.html#faq.using.bloda)


### PR DESCRIPTION
Current instructions use the master branch, which doesn't work.  This PR changes the documentation to use the main branch instead.

Based on CONTRIBUTING.md, I considered this too insubstantial to make an issue (just a 1 word change), but let me know if you'd like me to file such an issue now and/or going forward.